### PR TITLE
Remove $ from distinct_id

### DIFF
--- a/go/tracking/mixpanel.go
+++ b/go/tracking/mixpanel.go
@@ -85,7 +85,7 @@ func (b *MixpanelBackend) Track(ctx context.Context, name string, distinctID str
 		properties[k] = v
 	}
 
-	properties["$distinct_id"] = distinctID
+	properties["distinct_id"] = distinctID
 
 	return b.track(ctx, name, properties)
 

--- a/go/tracking/mixpanel_test.go
+++ b/go/tracking/mixpanel_test.go
@@ -27,14 +27,14 @@ func TestMixpanelBackend_Track(t *testing.T) {
 		assert.Equal(t, "sample", transport.received.Event)
 	})
 
-	t.Run("sets $distinct_id ", func(t *testing.T) {
+	t.Run("sets distinct_id ", func(t *testing.T) {
 		client, transport := tripper(1, "")
 
 		be := tracking.NewMixpanelBackend("apiKey", client)
 		err := be.Track(ctx, "sample", "000000", map[string]string{})
 
 		require.NoError(t, err)
-		assert.Equal(t, "000000", transport.received.Properties["$distinct_id"])
+		assert.Equal(t, "000000", transport.received.Properties["distinct_id"])
 	})
 
 	t.Run("sets token", func(t *testing.T) {


### PR DESCRIPTION
The `distinct_id` field should not be prefixed with a $ sign as documented here https://developer.mixpanel.com/reference/http#events